### PR TITLE
Add Trajectory mode to the visualiser

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 
 [weakdeps]
+BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
 GLFW = "f7f18e0c-5ee9-5ccd-a5bf-e8befd85ed98"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
@@ -20,7 +21,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
-VisualiserExt = ["FFMPEG", "GLFW", "Observables", "PrettyTables", "Printf", "StaticArrays"]
+VisualiserExt = ["BangBang", "FFMPEG", "GLFW", "Observables", "PrettyTables", "Printf", "StaticArrays"]
 
 [compat]
 julia = "1.6"

--- a/docs/src/intro/getting_started.md
+++ b/docs/src/intro/getting_started.md
@@ -63,11 +63,62 @@ visualise!(model, data, controller=random_controller!)
 ```
 ![](humanoid_random_demo.gif)
 
-Press F1 for help after running the visualiser to print the available options in a terminal. Some of the most interesting are:
+Press `F1` for help after running the visualiser to print the available options in a terminal. Some of the most interesting are:
 - Press `CTRL+RightArrow` (or `CMD` for Mac) to cycle between the passive dynamics and the controlled motion
 - Press `SPACE` to pause/unpause
 - Double-click on an object select it
 - `CTRL+RightClick` and drag to apply a force
+- Press `Backspace` to reset the model
 - Press `ESC` to exit the simulation
+
+## Visualising a Trajectory
+
+Sometimes it will be more convenient to simulate the motion of a MuJoCo model and save its response for later analysis. The visualiser includes a `Trajectory` mode to enable this. Let's [`reset!`](@ref) our humanoid model and set its initial height to 2 metres above the ground.
+
+```@example demo
+reset!(model, data)
+data.qpos[3] = 2
+forward!(model, data) # Propagate the physics forward 
+```
+
+The motion of every MuJoCo model can be described by some physical [state vector](https://mujoco.readthedocs.io/en/stable/computation/index.html#physics-state) consisting of the positions and velocities of its components, and the state of its actuators. We have included [`get_physics_state`](@ref) and [`set_physics_state!`](@ref) to allow users to record (and set) the states of a model during simulation. Let's simulate our humanoid for another 100 timesteps and record its state.
+
+```@example demo
+tmax = 400
+nx = model.nq + model.nv + model.na # State vector dimension
+states = zeros(nx, tmax)
+for t in 1:tmax
+    states[:,t] = get_physics_state(model, data)
+    step!(model, data)
+end
+```
+
+We'll also go back and save the humanoid states under our random controller. 
+```@example demo
+reset!(model, data)
+ctrl_states = zeros(nx, tmax)
+for t in 1:tmax
+    ctrl_states[:,t] = get_physics_state(model, data)
+    random_controller!(model, data)
+    step!(model, data)
+end
+```
+
+We can now play back either the passive or controlled humanoid motion whenever we like using the `Trajectory` mode in the visualiser. This allows us to re-wind the simulation, simulate it backwards, skip forward/backwards a few frames, and add some cool visualisation features.
+
+```julia
+visualise!(model, data, trajectories = [states, ctrl_states])
+```
+![](humanoid_trajectories.gif)
+
+You might find the following tips useful:
+- Press `CTRL+RightArrow` (or `CMD` for Mac) to cycle between the passive dynamics and the saved trajectories
+- Press `F1` to see the new `Trajectory` mode button and mouse options, including:
+    - Press `UP` or `DOWN` to cycle between trajectories
+    - PRESS `CTRL+R` for reverse mode
+    - Press `CTRL+B` to turn burst-mode on
+    - Press `CTRL+D` to add a doppler shift
+
+We strongly recommend saving trajectories for later visualisation if you're simulating any particularly complicated tasks in MuJoCo. You can start up the visualiser with all three of the passive dynamics, controlled dynamics, and saved trajectories. See [`visualise!`](@ref) for details.
 
 Happy visualising!

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"

--- a/examples/visualise.jl
+++ b/examples/visualise.jl
@@ -16,6 +16,15 @@ for t in 1:tmax
     step!(model, data)
 end
 
+# Simulate with a controller
+reset!(model, data)
+ctrl_states = zeros(nx, tmax)
+for t in 1:tmax
+    ctrl_states[:,t] = get_physics_state(model, data)
+    data.ctrl .= 2*randn()
+    step!(model, data)
+end
+
 # Try trajectory mode
 reset!(model, data)
-visualise!(model, data, trajectories = states)
+visualise!(model, data, trajectories = [states, ctrl_states])

--- a/examples/visualise.jl
+++ b/examples/visualise.jl
@@ -1,3 +1,21 @@
 using MuJoCo
 init_visualiser()
-MuJoCo.Visualiser.test_visualiser()
+# MuJoCo.Visualiser.test_visualiser()
+
+# Load model in specific state
+model = load_model("cartpole.xml")
+data = init_data(model)
+data.qpos[2] = 0.01
+
+# Simulate for some time and log states
+tmax = 500
+nx = model.nq + model.nv + model.na
+states = zeros(nx, tmax)
+for t in 1:tmax
+    states[:,t] = get_physics_state(model, data)
+    step!(model, data)
+end
+
+# Try trajectory mode
+reset!(model, data)
+visualise!(model, data, trajectories = states)

--- a/ext/VisualiserExt/VisualiserExt.jl
+++ b/ext/VisualiserExt/VisualiserExt.jl
@@ -13,6 +13,7 @@ if isdefined(Base, :get_extension)
     using MuJoCo.LibMuJoCo: mjrRect
     using MuJoCo.Visualiser
 
+    using BangBang
     using FFMPEG
     using GLFW: GLFW, Window, Key, Action, MouseButton, GetKey, RELEASE, PRESS, REPEAT
     using Observables: Observable, on, off
@@ -28,6 +29,7 @@ else
     using ..MuJoCo.LibMuJoCo: mjrRect
     using ..MuJoCo.Visualiser
 
+    using ..BangBang
     using ..FFMPEG
     using ..GLFW: GLFW, Window, Key, Action, MouseButton, GetKey, RELEASE, PRESS, REPEAT
     using ..Observables: Observable, on, off

--- a/ext/VisualiserExt/defaulthandlers.jl
+++ b/ext/VisualiserExt/defaulthandlers.jl
@@ -203,14 +203,6 @@ function handlers(e::Engine)
                 ispress_or_repeat(ev.action) && reset!(p, mode(e))
             end,
 
-            onkey(GLFW.KEY_R, MOD_CONTROL, what = "Toggle reverse") do s, ev
-                if ispress_or_repeat(ev.action)
-                    ui.reversed = !ui.reversed
-                    p.timer.rate *= -1
-                    resettime!(p)
-                end
-            end,
-
             onkey(GLFW.KEY_SPACE, what = "Pause") do s, ev
                 ispress_or_repeat(ev.action) && setpause!(ui, p, !ui.paused)
             end,
@@ -224,19 +216,6 @@ function handlers(e::Engine)
                     steps = s.shift ? 50 : 1
                     for _ = 1:steps
                         forwardstep!(p, mode(e))
-                    end
-                end
-            end,
-
-            onevent(
-                KeyEvent,
-                when = describe(GLFW.KEY_LEFT),
-                what = "Step backwards when paused (hold SHIFT for $(SHIFTSTEPSPERKEY) steps)"
-            ) do s, ev
-                if ui.paused && ev.key === GLFW.KEY_LEFT && ispress_or_repeat(ev.action)
-                    steps = s.shift ? 50 : 1
-                    for _ = 1:steps
-                        reversestep!(p, mode(e))
                     end
                 end
             end,

--- a/ext/VisualiserExt/defaulthandlers.jl
+++ b/ext/VisualiserExt/defaulthandlers.jl
@@ -199,7 +199,17 @@ function handlers(e::Engine)
                 end
             end,
 
-            # TODO: see https://github.com/JamieMair/MuJoCo.jl/issues/43
+            onkey(GLFW.KEY_BACKSPACE, what = "Reset model") do s, ev
+                ispress_or_repeat(ev.action) && reset!(p, mode(e))
+            end,
+
+            onkey(GLFW.KEY_R, MOD_CONTROL, what = "Toggle reverse") do s, ev
+                if ispress_or_repeat(ev.action)
+                    ui.reversed = !ui.reversed
+                    p.timer.rate *= -1
+                    resettime!(p)
+                end
+            end,
 
             onkey(GLFW.KEY_SPACE, what = "Pause") do s, ev
                 ispress_or_repeat(ev.action) && setpause!(ui, p, !ui.paused)
@@ -218,7 +228,18 @@ function handlers(e::Engine)
                 end
             end,
 
-            # TODO: see https://github.com/JamieMair/MuJoCo.jl/issues/42
+            onevent(
+                KeyEvent,
+                when = describe(GLFW.KEY_LEFT),
+                what = "Step backwards when paused (hold SHIFT for $(SHIFTSTEPSPERKEY) steps)"
+            ) do s, ev
+                if ui.paused && ev.key === GLFW.KEY_LEFT && ispress_or_repeat(ev.action)
+                    steps = s.shift ? 50 : 1
+                    for _ = 1:steps
+                        reversestep!(p, mode(e))
+                    end
+                end
+            end,
 
             onkey(GLFW.KEY_ENTER, what = "Toggle speed mode") do s, ev
                 if ispress_or_repeat(ev.action)

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -16,6 +16,12 @@ function forwardstep!(p::PhysicsState)
     return p
 end
 
+supportsreverse(::EngineMode) = false
+function reversestep!(p, m::EngineMode)
+    supportsreverse(m) && error("supportsreverse was true but reversestep! undefined")
+    return p
+end
+
 
 ############ EngineMode ############
 
@@ -32,7 +38,7 @@ end
 nameof(m::EngineMode) = string(Base.nameof(typeof(m)))
 setup!(ui, p, ::EngineMode) = ui
 teardown!(ui, p, ::EngineMode) = ui
-# reset!(p, ::EngineMode) = (reset!(p.model); p)   # TODO: reset! is highly model-dependent
+reset!(p, ::EngineMode) = (reset!(p.model); p)
 pausestep!(p, ::EngineMode) = pausestep!(p)
 prepare!(ui, p, ::EngineMode) = ui
 modeinfo(io1, io2, ui, p, ::EngineMode) = nothing
@@ -73,3 +79,253 @@ function modeinfo(io1, io2, ui::UIState, p::PhysicsState, x::Controller)
     @printf io2 "%.2fx\n" x.realtimefactor
     return nothing
 end
+
+############ Trajectory ############
+
+mutable struct Trajectory{TR<:AbsVec{<:AbsMat}} <: EngineMode
+    trajectories::TR
+    k::Int
+    t::Int
+
+    burstmode::Bool
+    bf_idx::Int
+    bf_range::LinRange{Float64}
+    bg_idx::Int
+    bg_range::LinRange{Float64}
+    doppler::Bool
+end
+function Trajectory{TR}(trajectories) where {TR<:AbsVec{<:AbsMat}}
+    Trajectory{TR}(
+        trajectories, 1, 1, 
+        false, 1, LinRange(0, 1, 2), 1, LinRange(0, 1, 2), false
+    )
+end
+Trajectory(trajectories::AbsVec{<:AbsMat}) = Trajectory{typeof(trajectories)}(trajectories)
+Trajectory(trajectories::AbsMat) = Trajectory([trajectories])
+
+getT(m::Trajectory) = size(m.trajectories[m.k], 2)
+gettraj(m::Trajectory) = m.trajectories[m.k]
+
+function setup!(ui::UIState, p::PhysicsState, m::Trajectory)
+    setburstmodeparams!(m, p)
+    setstate!(m, p)
+    return ui
+end
+
+function reset!(p::PhysicsState, m::Trajectory)
+    m.t = 1 
+    setstate!(m, p)
+    return p
+end
+
+function forwardstep!(p::PhysicsState, m::Trajectory)
+    m.t = inc(m.t, 1, getT(m))
+    setstate!(m, p)
+    return p
+end
+
+supportsreverse(::Trajectory) = true
+function reversestep!(p::PhysicsState, m::Trajectory)
+    m.t = dec(m.t, 1, getT(m))
+    setstate!(m, p)
+    return p
+end
+
+function prepare!(ui::UIState, p::PhysicsState, m::Trajectory)
+    if m.burstmode
+        bf = round(Int, m.bf_range[m.bf_idx])
+        bg = m.bg_range[m.bg_idx]
+        burst!(ui, p, gettraj(m), bf, m.t, gamma = bg, doppler = m.doppler)
+    end
+    return ui
+end
+
+function modeinfo(io1, io2, ui::UIState, p::PhysicsState, m::Trajectory)
+    println(io1, "t")
+    println(io2, "$(m.t)/$(getT(m))")
+    println(io1, "k")
+    println(io2, "$(m.k)/$(length(m.trajectories))")
+
+    n = length(m.bf_range)
+    println(io1, "Burst Mode")
+    println(io2, m.burstmode ? "Enabled" : "Disabled")
+    println(io1, "Burst Factor")
+    println(io2, "$(m.bf_idx)/$n")
+    println(io1, "Burst Gamma")
+    println(io2, "$(m.bg_idx)/$n")
+    println(io1, "Burst Doppler")
+    println(io2, m.doppler ? "Enabled" : "Disabled")
+
+    return nothing
+end
+
+# function handlers(ui::UIState, p::PhysicsState, m::Trajectory)
+#     return let ui=ui, p=p, m=m
+#         [
+#             onscroll(MOD_CONTROL, what = "Change burst factor") do s, ev
+#                 m.bf_idx = clamp(m.bf_idx + ev.dy, 1, length(m.bf_range))
+#             end,
+
+#             onscroll(MOD_SHIFT, what = "Change burst decay rate") do s, ev
+#                 m.bg_idx = clamp(m.bg_idx + ev.dy, 1, length(m.bg_range))
+#             end,
+
+#             onkey(GLFW.KEY_B, MOD_CONTROL, what = "Toggle burst mode") do s, ev
+#                 ispress_or_repeat(ev.action) && (m.burstmode = !m.burstmode)
+#             end,
+
+#             onkey(GLFW.KEY_D, MOD_CONTROL, what = "Toggle burst mode doppler effect") do s, ev
+#                 ispress_or_repeat(ev.action) && (m.doppler = !m.doppler)
+#             end,
+
+#             onkey(GLFW.KEY_UP, what = "Cycle forwards through trajectories") do s, ev
+#                 if ispress_or_repeat(ev.action)
+#                     m.k = inc(m.k, 1, length(m.trajectories))
+#                     ax = axes(gettraj(m), 2)
+#                     checkbounds(Bool, ax, m.t) || (m.t = last(ax))
+#                     setburstmodeparams!(m, p)
+#                     setstate!(m, p)
+#                 end
+#             end,
+
+#             onkey(GLFW.KEY_DOWN, what = "Cycle backwards through trajectories") do s, ev
+#                 if ispress_or_repeat(ev.action)
+#                     m.k = dec(m.k, 1, length(m.trajectories))
+#                     ax = axes(gettraj(m), 2)
+#                     checkbounds(Bool, ax, m.t) || (m.t = last(ax))
+#                     setburstmodeparams!(m, p)
+#                     setstate!(m, p)
+#                 end
+#             end,
+#         ]
+#     end
+# end
+
+# function setburstmodeparams!(m::Trajectory, p::PhysicsState)
+#     steps = 40 # n scroll increments
+
+#     # Params calibrated on cartpole and scaled accordingly
+#     # Rendering up to bf0_max states for a len0 length trajectory
+#     # with a timestep of dt0 and gamma0 looks reasonalbe.
+#     len0 = 100
+#     bf0_max = 50
+#     gamma0 = 0.85
+#     dt0 = 0.01
+
+#     dt = timestep(p.model)
+#     len = size(gettraj(m), 2)
+
+#     bf_max = round(Int, bf0_max * (len / len0) * (dt / dt0))
+#     gamma = gamma0^(dt / dt0)
+
+#     m.bf_range = LinRange{Float64}(1, bf_max, steps) # render between 1 and bf_max states
+#     m.bg_range = LinRange{Float64}(gamma, 1, steps)
+
+#     m.bf_idx = round(Int, steps / 2)
+#     m.bg_idx = steps
+
+#     return m
+# end
+
+# @inline function setstate!(m::Trajectory, p::PhysicsState)
+#     LyceumMuJoCo.setstate!(p.model, view(gettraj(m), :, m.t))
+#     return m
+# end
+
+# getT(m::Trajectory) = size(m.trajectories[m.k], 2)
+# gettraj(m::Trajectory) = m.trajectories[m.k]
+
+
+# ####
+# #### Util
+# ####
+
+# function burst!(
+#     ui::UIState,
+#     p::PhysicsState,
+#     states::AbstractMatrix,
+#     n::Integer,
+#     t::Integer;
+#     gamma::Real = 0.9995,
+#     alphamin::Real = 0.05,
+#     alphamax::Real = 0.55,
+#     doppler::Bool = true,
+# )
+#     T = size(states, 2)
+
+#     T >= n > 0 || error("n must be in range [1, size(states, 2)]")
+#     0 < t || error("t must be > 0")
+#     0 < gamma <= 1|| error("gamma must be in range (0, 1)")
+#     0 < alphamin <= 1 || error("alphamin must be in range (0, 1]")
+#     0 < alphamax <= 1 || error("alphamin must be in range (0, 1]")
+
+#     scn = ui.scn
+#     sim = getsim(p.model)
+#     n = min(n, fld(MAXGEOM, sim.m.ngeom))
+#     geoms = unsafe_wrap(Array, scn[].geoms, scn[].maxgeom)
+
+#     function color!(tprime, from)
+#         for i = from:scn[].ngeom
+#             geom = @inbounds geoms[i]
+#             if geom.category == Int(MJCore.mjCAT_DYNAMIC)
+#                 dist = abs(tprime - t)
+#                 r, g, b, alpha0 = geom.rgba
+
+#                 alpha = alpha0 * gamma^dist
+
+#                 if doppler
+#                     g = 0
+#                     if tprime < t
+#                         beta = (dist + 1) / t / 2 + 0.5
+#                         r = beta * r
+#                         b = (1 - beta) * b
+#                     else
+#                         beta = dist / (T - t) / 2 + 0.5
+#                         r = (1 - beta) * r
+#                         b = beta * b
+#                     end
+#                     r = clamp(r, 0, 1)
+#                     b = clamp(b, 0, 1)
+#                 end
+
+#                 geoms[i] = @set!! geom.rgba = SVector{4,Cfloat}(r, g, b, alpha)
+#             end
+#         end
+#     end
+
+#     LyceumMuJoCo.setstate!(p.model, view(states, :, t))
+#     mjv_updateScene(
+#         sim.m,
+#         sim.d,
+#         ui.vopt,
+#         p.pert,
+#         ui.cam,
+#         MJCore.mjCAT_ALL,
+#         scn,
+#     )
+
+#     if n > 1
+#         fromidx = scn[].ngeom + 1
+#         from = scn[].ngeom + 1
+#         for tprime in Iterators.map(x -> round(Int, x), LinRange(1, T, n))
+#             if tprime != t
+#                 LyceumMuJoCo.setstate!(p.model, view(states, :, tprime))
+#                 mjv_addGeoms(
+#                     sim.m,
+#                     sim.d,
+#                     ui.vopt,
+#                     p.pert,
+#                     MJCore.mjCAT_DYNAMIC,
+#                     scn,
+#                 )
+#                 color!(tprime, from)
+#             end
+#             from = scn[].ngeom + 1
+#         end
+#     end
+
+#     # reset the model to the state it had when it was passed in
+#     LyceumMuJoCo.setstate!(p.model, view(states, :, t))
+
+#     return ui
+# end

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -227,10 +227,8 @@ function setburstmodeparams!(m::Trajectory, p::PhysicsState)
     return m
 end
 
-# TODO: Need to define setstate! and getstate! for generic MuJoCo models.
-# Probably best to use x = (qpos, qvel, act)
 @inline function setstate!(m::Trajectory, p::PhysicsState)
-    setstate!(p.model, view(gettraj(m), :, m.t))
+    set_physics_state!(p.model, view(gettraj(m), :, m.t))
     return m
 end
 

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -159,81 +159,80 @@ function modeinfo(io1, io2, ui::UIState, p::PhysicsState, m::Trajectory)
     return nothing
 end
 
-# function handlers(ui::UIState, p::PhysicsState, m::Trajectory)
-#     return let ui=ui, p=p, m=m
-#         [
-#             onscroll(MOD_CONTROL, what = "Change burst factor") do s, ev
-#                 m.bf_idx = clamp(m.bf_idx + ev.dy, 1, length(m.bf_range))
-#             end,
+function handlers(ui::UIState, p::PhysicsState, m::Trajectory)
+    return let ui=ui, p=p, m=m
+        [
+            onscroll(MOD_CONTROL, what = "Change burst factor") do s, ev
+                m.bf_idx = clamp(m.bf_idx + ev.dy, 1, length(m.bf_range))
+            end,
 
-#             onscroll(MOD_SHIFT, what = "Change burst decay rate") do s, ev
-#                 m.bg_idx = clamp(m.bg_idx + ev.dy, 1, length(m.bg_range))
-#             end,
+            onscroll(MOD_SHIFT, what = "Change burst decay rate") do s, ev
+                m.bg_idx = clamp(m.bg_idx + ev.dy, 1, length(m.bg_range))
+            end,
 
-#             onkey(GLFW.KEY_B, MOD_CONTROL, what = "Toggle burst mode") do s, ev
-#                 ispress_or_repeat(ev.action) && (m.burstmode = !m.burstmode)
-#             end,
+            onkey(GLFW.KEY_B, MOD_CONTROL, what = "Toggle burst mode") do s, ev
+                ispress_or_repeat(ev.action) && (m.burstmode = !m.burstmode)
+            end,
 
-#             onkey(GLFW.KEY_D, MOD_CONTROL, what = "Toggle burst mode doppler effect") do s, ev
-#                 ispress_or_repeat(ev.action) && (m.doppler = !m.doppler)
-#             end,
+            onkey(GLFW.KEY_D, MOD_CONTROL, what = "Toggle burst mode doppler effect") do s, ev
+                ispress_or_repeat(ev.action) && (m.doppler = !m.doppler)
+            end,
 
-#             onkey(GLFW.KEY_UP, what = "Cycle forwards through trajectories") do s, ev
-#                 if ispress_or_repeat(ev.action)
-#                     m.k = inc(m.k, 1, length(m.trajectories))
-#                     ax = axes(gettraj(m), 2)
-#                     checkbounds(Bool, ax, m.t) || (m.t = last(ax))
-#                     setburstmodeparams!(m, p)
-#                     setstate!(m, p)
-#                 end
-#             end,
+            onkey(GLFW.KEY_UP, what = "Cycle forwards through trajectories") do s, ev
+                if ispress_or_repeat(ev.action)
+                    m.k = inc(m.k, 1, length(m.trajectories))
+                    ax = axes(gettraj(m), 2)
+                    checkbounds(Bool, ax, m.t) || (m.t = last(ax))
+                    setburstmodeparams!(m, p)
+                    setstate!(m, p)
+                end
+            end,
 
-#             onkey(GLFW.KEY_DOWN, what = "Cycle backwards through trajectories") do s, ev
-#                 if ispress_or_repeat(ev.action)
-#                     m.k = dec(m.k, 1, length(m.trajectories))
-#                     ax = axes(gettraj(m), 2)
-#                     checkbounds(Bool, ax, m.t) || (m.t = last(ax))
-#                     setburstmodeparams!(m, p)
-#                     setstate!(m, p)
-#                 end
-#             end,
-#         ]
-#     end
-# end
+            onkey(GLFW.KEY_DOWN, what = "Cycle backwards through trajectories") do s, ev
+                if ispress_or_repeat(ev.action)
+                    m.k = dec(m.k, 1, length(m.trajectories))
+                    ax = axes(gettraj(m), 2)
+                    checkbounds(Bool, ax, m.t) || (m.t = last(ax))
+                    setburstmodeparams!(m, p)
+                    setstate!(m, p)
+                end
+            end,
+        ]
+    end
+end
 
-# function setburstmodeparams!(m::Trajectory, p::PhysicsState)
-#     steps = 40 # n scroll increments
+function setburstmodeparams!(m::Trajectory, p::PhysicsState)
+    steps = 40 # n scroll increments
 
-#     # Params calibrated on cartpole and scaled accordingly
-#     # Rendering up to bf0_max states for a len0 length trajectory
-#     # with a timestep of dt0 and gamma0 looks reasonalbe.
-#     len0 = 100
-#     bf0_max = 50
-#     gamma0 = 0.85
-#     dt0 = 0.01
+    # Params calibrated on cartpole and scaled accordingly
+    # Rendering up to bf0_max states for a len0 length trajectory
+    # with a timestep of dt0 and gamma0 looks reasonalbe.
+    len0 = 100
+    bf0_max = 50
+    gamma0 = 0.85
+    dt0 = 0.01
 
-#     dt = timestep(p.model)
-#     len = size(gettraj(m), 2)
+    dt = timestep(p.model)
+    len = size(gettraj(m), 2)
 
-#     bf_max = round(Int, bf0_max * (len / len0) * (dt / dt0))
-#     gamma = gamma0^(dt / dt0)
+    bf_max = round(Int, bf0_max * (len / len0) * (dt / dt0))
+    gamma = gamma0^(dt / dt0)
 
-#     m.bf_range = LinRange{Float64}(1, bf_max, steps) # render between 1 and bf_max states
-#     m.bg_range = LinRange{Float64}(gamma, 1, steps)
+    m.bf_range = LinRange{Float64}(1, bf_max, steps) # render between 1 and bf_max states
+    m.bg_range = LinRange{Float64}(gamma, 1, steps)
 
-#     m.bf_idx = round(Int, steps / 2)
-#     m.bg_idx = steps
+    m.bf_idx = round(Int, steps / 2)
+    m.bg_idx = steps
 
-#     return m
-# end
+    return m
+end
 
+# TODO: Need to define setstate! and getstate! for generic MuJoCo models.
+# Probably best to use x = (qpos, qvel, act)
 # @inline function setstate!(m::Trajectory, p::PhysicsState)
 #     LyceumMuJoCo.setstate!(p.model, view(gettraj(m), :, m.t))
 #     return m
 # end
-
-# getT(m::Trajectory) = size(m.trajectories[m.k], 2)
-# gettraj(m::Trajectory) = m.trajectories[m.k]
 
 
 # ####

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -32,7 +32,7 @@ end
 nameof(m::EngineMode) = string(Base.nameof(typeof(m)))
 setup!(ui, p, ::EngineMode) = ui
 teardown!(ui, p, ::EngineMode) = ui
-reset!(p, ::EngineMode) = (reset!(p.model, p.data); p)
+reset!(p, ::EngineMode) = (MuJoCo.reset!(p.model, p.data); p)
 pausestep!(p, ::EngineMode) = pausestep!(p)
 prepare!(ui, p, ::EngineMode) = ui
 modeinfo(io1, io2, ui, p, ::EngineMode) = nothing

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -223,6 +223,7 @@ end
 
 @inline function setstate!(m::Trajectory, p::PhysicsState)
     set_physics_state!(p.model, p.data, view(gettraj(m), :, m.t))
+    forward!(p.model, p.data)
     return m
 end
 

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -137,7 +137,7 @@ end
 function modeinfo(io1, io2, ui::UIState, p::PhysicsState, m::Trajectory)
     println(io1, "t")
     println(io2, "$(m.t)/$(getT(m))")
-    println(io1, "k")
+    println(io1, "Trajectory ID")
     println(io2, "$(m.k)/$(length(m.trajectories))")
 
     n = length(m.bf_range)

--- a/ext/VisualiserExt/modes.jl
+++ b/ext/VisualiserExt/modes.jl
@@ -229,10 +229,10 @@ end
 
 # TODO: Need to define setstate! and getstate! for generic MuJoCo models.
 # Probably best to use x = (qpos, qvel, act)
-# @inline function setstate!(m::Trajectory, p::PhysicsState)
-#     LyceumMuJoCo.setstate!(p.model, view(gettraj(m), :, m.t))
-#     return m
-# end
+@inline function setstate!(m::Trajectory, p::PhysicsState)
+    setstate!(p.model, view(gettraj(m), :, m.t))
+    return m
+end
 
 
 # ####

--- a/ext/VisualiserExt/util.jl
+++ b/ext/VisualiserExt/util.jl
@@ -30,6 +30,7 @@ function init_figsensor!(figsensor::VisualiserFigure)
     return figsensor
 end
 
+# Useful for trajectory mode
 @inline inc(x::Integer, min::Integer, max::Integer) = ifelse(x == max, min, x + 1)
 @inline dec(x::Integer, min::Integer, max::Integer) = ifelse(x == min, max, x - 1)
 
@@ -84,7 +85,3 @@ function get_terminalsize()
         displaysize(stdout)
     end
 end
-
-# Useful for trajectory mode
-@inline inc(x::Integer, min::Integer, max::Integer) = ifelse(x == max, min, x + 1)
-@inline dec(x::Integer, min::Integer, max::Integer) = ifelse(x == min, max, x - 1)

--- a/ext/VisualiserExt/util.jl
+++ b/ext/VisualiserExt/util.jl
@@ -84,3 +84,7 @@ function get_terminalsize()
         displaysize(stdout)
     end
 end
+
+# Useful for trajectory mode
+@inline inc(x::Integer, min::Integer, max::Integer) = ifelse(x == max, min, x + 1)
+@inline dec(x::Integer, min::Integer, max::Integer) = ifelse(x == min, max, x - 1)

--- a/ext/VisualiserExt/visualiser.jl
+++ b/ext/VisualiserExt/visualiser.jl
@@ -6,8 +6,8 @@ function MuJoCo.Visualiser.visualise!(
     trajectories = nothing
 )
     modes = EngineMode[PassiveDynamics()]
-    !isnothing(trajectories) && push!(modes, Trajectory(trajectories))
     !isnothing(controller) && push!(modes, Controller(controller))
+    !isnothing(trajectories) && push!(modes, Trajectory(trajectories))
 
     run!(Engine(default_windowsize(), m, d, Tuple(modes)))
     return nothing

--- a/ext/VisualiserExt/visualiser.jl
+++ b/ext/VisualiserExt/visualiser.jl
@@ -3,12 +3,13 @@
 function MuJoCo.Visualiser.visualise!(
     m::Model, d::Data; 
     controller = nothing, 
-    # trajectories = nothing
+    trajectories = nothing
 )
     modes = EngineMode[PassiveDynamics()]
+    !isnothing(trajectories) && push!(modes, Trajectory(trajectories))
     !isnothing(controller) && push!(modes, Controller(controller))
-    e = Engine(default_windowsize(), m, d, Tuple(modes))
-    run!(e)
+
+    run!(Engine(default_windowsize(), m, d, Tuple(modes)))
     return nothing
 end
 

--- a/src/MuJoCo.jl
+++ b/src/MuJoCo.jl
@@ -134,7 +134,7 @@ end
 
 Set the state vector of a MuJoCo model.
 
-The state vector is [joint positions, joint velocities, actuator states] with dimension (nq, nv, na). 
+The state vector is [joint positions, joint velocities, actuator states] with dimension (nq, nv, na). Call [`forward!`](@ref) after setting the state to compute all derived quantities in the `Data` object according to the new state.
 
 See also [`mj_setState`](@ref) and [`get_physics_state`](@ref).
 """
@@ -156,6 +156,7 @@ Add the following packages to your project to be able to use
 the visualisation features, or run "install_visualiser()".
 
 # Packages:
+- BangBang
 - FFMPEG
 - GLFW
 - Observables
@@ -164,7 +165,7 @@ the visualisation features, or run "install_visualiser()".
 - StaticArrays
 """
 function init_visualiser()
-    @eval Main using FFMPEG, GLFW, Observables, PrettyTables, Printf, StaticArrays
+    @eval Main using BangBang, FFMPEG, GLFW, Observables, PrettyTables, Printf, StaticArrays
     if isdefined(Base, :get_extension)
         @eval Main Base.retry_load_extensions()
     end
@@ -177,6 +178,7 @@ Installs the necessary packages for the running the visualiser
 into the current running environment.
 
 # Packages:
+- BangBang
 - FFMPEG
 - GLFW
 - Observables
@@ -186,19 +188,21 @@ into the current running environment.
 """
 function install_visualiser()
     @eval Main import Pkg
-    @eval Main Pkg.add(["FFMPEG", "GLFW", "Observables", "PrettyTables", "Printf", "StaticArrays"])
+    @eval Main Pkg.add(["BangBang", "FFMPEG", "GLFW", "Observables", "PrettyTables", "Printf", "StaticArrays"])
 end
 
 @static if !isdefined(Base, :get_extension)
 function __init__()
     @static if !isdefined(Base, :get_extension)
-        @require FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a" begin
-            @require GLFW = "f7f18e0c-5ee9-5ccd-a5bf-e8befd85ed98" begin
-                @require Observables = "510215fc-4207-5dde-b226-833fc4488ee2" begin
-                    @require PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d" begin
-                        @require Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7" begin
-                            @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin
-                                include("../ext/VisualiserExt/VisualiserExt.jl")
+        @require BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66" begin 
+            @require FFMPEG = "c87230d0-a227-11e9-1b43-d7ebe4e7570a" begin
+                @require GLFW = "f7f18e0c-5ee9-5ccd-a5bf-e8befd85ed98" begin
+                    @require Observables = "510215fc-4207-5dde-b226-833fc4488ee2" begin
+                        @require PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d" begin
+                            @require Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7" begin
+                                @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" begin
+                                    include("../ext/VisualiserExt/VisualiserExt.jl")
+                                end
                             end
                         end
                     end

--- a/src/MuJoCo.jl
+++ b/src/MuJoCo.jl
@@ -44,7 +44,7 @@ const DATA_TYPES = Union{Data, NamedAccess.NamedData}
 import .Visualiser: visualise!
 
 
-export init_data, step!, forward!, timestep, reset!, resetkey!, getstate, setstate!
+export init_data, step!, forward!, timestep, reset!, resetkey!, get_physics_state, set_physics_state!
 export init_visualiser, install_visualiser, visualise!
 
 include("io.jl")
@@ -114,15 +114,15 @@ timestep(model::MODEL_TYPES) = model.opt.timestep
 
 """
 
-    getstate(m::Model, d::Data)
+    get_physics_state(m::Model, d::Data)
 
 Extract the state vector of a MuJoCo model.
 
 The state vector is [joint positions, joint velocities, actuator states] with dimension (nq, nv, na). 
 
-See also [`mj_getState`](@ref) and [`setstate!`](@ref).
+See also [`mj_getState`](@ref) and [`set_physics_state!`](@ref).
 """
-function getstate(m::Model, d::Data)
+function get_physics_state(m::Model, d::Data)
     x = mj_zeros(m.nq+m.nv+m.na)
     mj_getState(m, d, x, LibMuJoCo.mjSTATE_PHYSICS)
     return transpose(x)
@@ -130,15 +130,15 @@ end
 
 """
 
-    setstate!(m::Model, d::Data, x::AbstractVector)
+    set_physics_state!(m::Model, d::Data, x::AbstractVector)
 
 Set the state vector of a MuJoCo model.
 
 The state vector is [joint positions, joint velocities, actuator states] with dimension (nq, nv, na). 
 
-See also [`mj_setState`](@ref) and [`getstate`](@ref).
+See also [`mj_setState`](@ref) and [`get_physics_state`](@ref).
 """
-function setstate!(m::Model, d::Data, x::AbstractVector)
+function set_physics_state!(m::Model, d::Data, x::AbstractVector)
     mj_setState(m, d, transpose(x), LibMuJoCo.mjSTATE_PHYSICS)
 end
 

--- a/src/visualiser.jl
+++ b/src/visualiser.jl
@@ -45,13 +45,15 @@ function test_visualiser end
 
 Starts an interactive visualization of a MuJoCo model specified by an instance of `Model` and `Data`.
 
-The visualizer has two "modes" that allow you to visualize passive dynamics or run a controller interactively. The passive dynamics mode is always available, while the controller mode is specified by the keyword argument below.
+The visualizer has three "modes" that allow you to visualize passive dynamics, run a controller interactively, or play back recorded trajectories. The passive dynamics mode is always available, while the controller and trajectory modes are specified by the keyword arguments below.
 
-Press F1 for help after running the visualiser to print the available options in a terminal.
+Press F1 for help after running the visualiser to print the available mouse/button options in the terminal.
 
 # Keywords
 
 - `controller`: a callback function with the signature `controller(m, d)`, called at each timestep, that applies a control input to the system (or does any other operation you like).
+
+- `trajectories`: a single trajectory or `Vector` of trajectories, where each trajectory is an `AbstractMatrix` of states with size `(nx, T)` where `nx = model.nq + model.nv + model.na` and `T` is the length of the trajectory. Note that each trajectory can have a different length.
 
 # Examples
 
@@ -63,14 +65,26 @@ init_visualiser()    # Load required dependencies into session
 # Load a model
 model, data = MuJoCo.sample_model_and_data()
 
+# Simulate and record a trajectory
+T = 200
+nx = model.nq + model.nv + model.na
+states = zeros(nx, T)
+for t in 1:T
+    states[:,t] = get_physics_state(model, data)
+    step!(model, data)
+end
+
 # Define a controller
 function ctrl!(m,d)
     d.ctrl .= 2*rand(m.nu) .- 1
 end
 
 # Run the visualiser
-visualise!(model, data, controller=ctrl!)
+reset!(model, data)
+visualise!(model, data, controller=ctrl!, trajectories = states)
 ```
+
+See also [`get_physics_state`](@ref) and [`reset!`](@ref).
 """
 function visualise! end
 


### PR DESCRIPTION
Added the `Trajectory` mode from https://github.com/JamieMair/MuJoCo.jl/issues/41 to the visualiser, including:

- Methods to set and get the physics state of a MuJoCo model, where the physics state is defined in the [MuJoCo docs](https://mujoco.readthedocs.io/en/stable/computation/index.html#physics-state)
- Added docs to demonstrate the trajectory mode
- Updated docstring for `visualise!`

All new functionality has been tested and is working.